### PR TITLE
Listen to all interfaces by default

### DIFF
--- a/main.mjs
+++ b/main.mjs
@@ -2,7 +2,7 @@ import { once } from "events";
 import { Redis } from "ioredis";
 import fastify from "fastify";
 
-const HOST = process.env.HOST ?? "127.0.0.1";
+const HOST = process.env.HOST ?? "0.0.0.0";
 const PORT = Number.parseInt(process.env.PORT ?? 3000);
 const PROM_PREFIX = process.env.PROM_PREFIX ?? "bull";
 const BULL_PREFIX = process.env.BULL_PREFIX ?? "bull";


### PR DESCRIPTION
Using 127.0.0.1 for binding wouldn't allow to access the exporter running in a container. Using 0.0.0.0 solves this issue.